### PR TITLE
Enforce single line statements if possible

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -213,6 +213,7 @@
     <rule ref="./src/InterNations/Sniffs/Syntax/BracesSniff.php"/>
     <rule ref="./src/InterNations/Sniffs/Whitespace/AlignedAssignmentSniff.php"/>
     <rule ref="./src/InterNations/Sniffs/Architecture/FormTypeConventionSniff.php"/>
+    <rule ref="./src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php"/>
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
     <rule ref="Squiz.Strings.EchoedStrings"/>

--- a/src/InterNations/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/InterNations/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -88,11 +88,8 @@ class SwitchDeclarationSniff implements CodeSnifferSniff
         $caseCount = 0;
         $foundDefault = false;
 
-        while (($nextCase = $file->findNext(
-            [T_CASE, T_DEFAULT, T_SWITCH],
-            ($nextCase + 1),
-            $switch['scope_closer']
-        )) !== false
+        while (($nextCase = $file->findNext([T_CASE, T_DEFAULT, T_SWITCH], ($nextCase + 1), $switch['scope_closer'])
+            ) !== false
         ) {
             // Skip nested SWITCH statements; they are handled on their own.
             if ($tokens[$nextCase]['code'] === T_SWITCH) {

--- a/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
@@ -1,0 +1,178 @@
+<?php
+namespace InterNations\Sniffs\Formatting;
+
+use PHP_CodeSniffer_File as CodeSnifferFile;
+use PHP_CodeSniffer_Sniff as CodeSnifferSniff;
+
+class ExpressionFormattingSniff implements CodeSnifferSniff
+{
+    public function register()
+    {
+        return [T_STRING, T_STATIC];
+    }
+
+    public function process(CodeSnifferFile $file, $stackPtr)
+    {
+        $tokens = $file->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+            $leftNonWhitespaceTokenPtr = $file->findPrevious([T_WHITESPACE], $stackPtr - 1, null, true);
+            $arrayOpenerToken = [T_EQUAL, T_RETURN, T_DOUBLE_ARROW];
+            if (!in_array($tokens[$leftNonWhitespaceTokenPtr]['code'], $arrayOpenerToken, true)) {
+                return;
+            }
+        } else {
+            if ($tokens[$stackPtr + 1]['code'] !== T_OPEN_PARENTHESIS) {
+                return;
+            }
+        }
+
+        $leftTokenPtr = $file->findPrevious([T_STRING, T_NS_SEPARATOR], $stackPtr - 1, null, true);
+        $invocationHints = [T_OBJECT_OPERATOR, T_PAAMAYIM_NEKUDOTAYIM, T_WHITESPACE, T_OPEN_TAG];
+        if (!in_array($tokens[$leftTokenPtr]['code'], $invocationHints)) {
+            return;
+        }
+
+        if (isset($tokens[$stackPtr - 2])
+            && in_array($tokens[$stackPtr - 2]['code'], [T_CLASS, T_INTERFACE, T_TRAIT])) {
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+            $openingToken = $tokens[$stackPtr];
+            $closingPtr = $openingToken['bracket_closer'];
+            $closingToken = $tokens[$closingPtr];
+            $stackPtr -= 2;
+        } else {
+            $openingToken = $tokens[$stackPtr + 1];
+            $closingPtr = $openingToken['parenthesis_closer'];
+            $closingToken = $tokens[$closingPtr];
+        }
+
+        if ($openingToken['line'] === $closingToken['line']) {
+            return;
+        }
+
+        $nestingLevel = 0;
+        $argumentsLine = '';
+        $whitespaceCount = 0;
+        $needsWhitespace = true;
+        for ($expressionPtr = $stackPtr + 2; $expressionPtr < $closingPtr; $expressionPtr++) {
+
+            $currentToken = $tokens[$expressionPtr];
+            switch ($currentToken['code']) {
+                case T_WHITESPACE:
+                    if (static::nextSignificantTokenClosesArray($file, $expressionPtr)) {
+                        $needsWhitespace = false;
+                        break;
+                    }
+                    static::append($argumentsLine, ' ', $whitespaceCount, $needsWhitespace);
+                    break;
+
+                case T_OPEN_SHORT_ARRAY:
+                case T_ARRAY:
+                case T_OPEN_PARENTHESIS:
+                    static::append($argumentsLine, $currentToken['content'], $whitespaceCount, $needsWhitespace);
+                    $nestingLevel++;
+                    $needsWhitespace = false;
+                    break;
+
+                case T_CLOSE_SHORT_ARRAY:
+                case T_CLOSE_PARENTHESIS:
+                    static::append($argumentsLine, $currentToken['content'], $whitespaceCount, $needsWhitespace);
+                    $nestingLevel--;
+                    $needsWhitespace = false;
+                    break;
+
+                case T_CONSTANT_ENCAPSED_STRING:
+                case T_VARIABLE:
+                    if (strpos($currentToken['content'], "\n") !== false) {
+                        // Ignore strings spanning multiple lines
+                        return;
+                    }
+                    static::append($argumentsLine, $currentToken['content'], $whitespaceCount, $needsWhitespace);
+                    break;
+
+                case T_HEREDOC:
+                case T_NOWDOC:
+                case T_CLOSURE:
+                case T_COMMENT:
+                case T_DOC_COMMENT:
+                    // Don’t continue checking
+                    return;
+                    break;
+
+                case T_COMMA:
+                    if (static::nextSignificantTokenClosesArray($file, $expressionPtr)) {
+                        $needsWhitespace = false;
+                        break;
+                    }
+                    static::append($argumentsLine, $currentToken['content'], $whitespaceCount, $needsWhitespace);
+                    break;
+
+                default:
+                    static::append($argumentsLine, $currentToken['content'], $whitespaceCount, $needsWhitespace);
+                    break;
+            }
+        }
+
+        $startPtr = $stackPtr;
+        do {
+            --$startPtr;
+        } while ($tokens[$stackPtr]['line'] === $tokens[$startPtr]['line']);
+
+        $endPtr = $expressionPtr;
+        do {
+            ++$endPtr;
+        } while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']);
+
+        $before = static::composeExpression($tokens, $startPtr + 1, $stackPtr + 1);
+        $after = static::composeExpression($tokens, $expressionPtr, $endPtr);
+
+
+        $expression = $before . trim($argumentsLine) . $after;
+
+        if (mb_strlen($expression, 'UTF-8') <= 120) {
+            $file->addError(
+                sprintf('Expression "%s" should be in one line', trim($expression)),
+                $stackPtr,
+                'OneLineExpression'
+            );
+        }
+    }
+
+    private static function composeExpression(array $tokens, $startPtr, $endPtr)
+    {
+        $expression = '';
+
+        for ($ptr = $startPtr; $ptr <= $endPtr; $ptr++) {
+            $expression .= $tokens[$ptr]['content'];
+        }
+
+        return $expression;
+    }
+
+    private static function append(&$expression, $content, &$whitespaceCount, &$needsWhitespace)
+    {
+        if ($content === ' ') {
+            if ($whitespaceCount === 0 && $needsWhitespace) {
+                $expression .= $content;
+                $whitespaceCount++;
+                return;
+            }
+            return;
+        }
+
+        $expression .= $content;
+        $whitespaceCount = 0;
+        $needsWhitespace = true;
+    }
+
+    private static function nextSignificantTokenClosesArray(CodeSnifferFile $file, $ptr)
+    {
+        $tokens = $file->getTokens();
+        $nextSignificantToken = $file->findNext(T_WHITESPACE, $ptr + 1, null, true);
+
+        return in_array($tokens[$nextSignificantToken]['code'], [T_CLOSE_SHORT_ARRAY, T_CLOSE_PARENTHESIS]);
+    }
+}

--- a/src/InterNations/Sniffs/Naming/AlternativeFunctionSniff.php
+++ b/src/InterNations/Sniffs/Naming/AlternativeFunctionSniff.php
@@ -69,14 +69,7 @@ class AlternativeFunctionSniff implements Sniff
             return;
         }
 
-        $beforeWhitespacePtr = $file->findPrevious(
-            [T_WHITESPACE],
-            $stackPtr - 1,
-            null,
-            true,
-            null,
-            true
-        );
+        $beforeWhitespacePtr = $file->findPrevious([T_WHITESPACE], $stackPtr - 1, null, true, null, true);
 
         if ($tokens[$beforeWhitespacePtr]['code'] == T_SEMICOLON) {
             $beforeWhitespacePtr++;

--- a/src/InterNations/Sniffs/Naming/FinalSniff.php
+++ b/src/InterNations/Sniffs/Naming/FinalSniff.php
@@ -47,30 +47,15 @@ class FinalSniff implements CodeSnifferSniff
                         || $className == 'EventType';
 
         if (!$isFinal && $shouldBeFinal && $methods === 0) {
-            $file->addError(
-                'Enum "%s" must be final',
-                $stackPtr,
-                'FinalClassEnum',
-                [$className]
-            );
+            $file->addError('Enum "%s" must be final', $stackPtr, 'FinalClassEnum', [$className]);
         }
 
         if (!$isFinal && $shouldBeFinal && $methods === $staticMethods) {
-            $file->addError(
-                'Static class "%s" must be final',
-                $stackPtr,
-                'FinalClassStatic',
-                [$className]
-            );
+            $file->addError('Static class "%s" must be final', $stackPtr, 'FinalClassStatic', [$className]);
         }
 
         if ($isFinal && !$shouldBeFinal) {
-            $file->addError(
-                'Class "%s" may not be final',
-                $stackPtr,
-                'FinalClassDisallowed',
-                [$className]
-            );
+            $file->addError('Class "%s" may not be final', $stackPtr, 'FinalClassDisallowed', [$className]);
         }
     }
 }

--- a/src/InterNations/Sniffs/Naming/MethodNameSniff.php
+++ b/src/InterNations/Sniffs/Naming/MethodNameSniff.php
@@ -20,21 +20,13 @@ class MethodNameSniff implements CodeSnifferSniff
 
         if (preg_match('/^getIs(?P<remainder>[A-Z].*)$/', $methodName, $matches)) {
             $file->addError(
-                sprintf(
-                    'Method name "%s()" is not allowed. Use "is%s()" instead',
-                    $methodName,
-                    $matches['remainder']
-                ),
+                sprintf('Method name "%s()" is not allowed. Use "is%s()" instead', $methodName, $matches['remainder']),
                 $stackPtr,
                 'BadIsser'
             );
         } elseif (preg_match('/^setIs(?P<remainder>[A-Z].*)$/', $methodName, $matches)) {
             $file->addError(
-                sprintf(
-                    'Method name "%s()" is not allowed. Use "set%s()" instead',
-                    $methodName,
-                    $matches['remainder']
-                ),
+                sprintf('Method name "%s()" is not allowed. Use "set%s()" instead', $methodName, $matches['remainder']),
                 $stackPtr,
                 'BadSetter'
             );

--- a/src/InterNations/Sniffs/Syntax/ClosureSniff.php
+++ b/src/InterNations/Sniffs/Syntax/ClosureSniff.php
@@ -74,28 +74,14 @@ class ClosureSniff implements CodeSnifferSniff
             );
         }
 
-        $thisPtr = $file->findNext(
-            [T_VARIABLE],
-            $scopeOpener,
-            $scopeCloser,
-            false,
-            '$this'
-        );
+        $thisPtr = $file->findNext([T_VARIABLE], $scopeOpener, $scopeCloser, false, '$this');
 
         if ($isStaticClosure && $thisPtr !== false) {
-            $file->addError(
-                'Static closure references $this. Remove static qualifier',
-                $thisPtr,
-                'closureStaticThis'
-            );
+            $file->addError('Static closure references $this. Remove static qualifier', $thisPtr, 'closureStaticThis');
         }
 
         if (!$isStaticClosure && $thisPtr === false) {
-            $file->addError(
-                'Closure does not reference $this. Add "static" qualifier',
-                $stackPtr,
-                'closureStatic'
-            );
+            $file->addError('Closure does not reference $this. Add "static" qualifier', $stackPtr, 'closureStatic');
         }
     }
 }

--- a/src/InterNations/Sniffs/Syntax/ShortArraySyntaxSniff.php
+++ b/src/InterNations/Sniffs/Syntax/ShortArraySyntaxSniff.php
@@ -13,10 +13,6 @@ class ShortArraySyntaxSniff implements CodeSnifferSniff
 
     public function process(CodeSnifferFile $file, $stackPtr)
     {
-        $file->addError(
-            'Legacy array syntax (array()) is discouraged. Use [] instead',
-            $stackPtr,
-            'legacyArraySyntax'
-        );
+        $file->addError('Legacy array syntax (array()) is discouraged. Use [] instead', $stackPtr, 'legacyArraySyntax');
     }
 }

--- a/src/InterNations/Sniffs/Waste/NonExecutableCodeSniff.php
+++ b/src/InterNations/Sniffs/Waste/NonExecutableCodeSniff.php
@@ -118,10 +118,7 @@ class NonExecutableCodeSniff implements CodeSnifferSniff
                 // This token closes the scope of a CASE or DEFAULT statement
                 // so any code between this token and the next CASE, DEFAULT or
                 // end of SWITCH token will not be executable.
-                $next = $phpcsFile->findNext(
-                    [T_CASE, T_DEFAULT, T_CLOSE_CURLY_BRACKET],
-                    ($stackPtr + 1)
-                );
+                $next = $phpcsFile->findNext([T_CASE, T_DEFAULT, T_CLOSE_CURLY_BRACKET], ($stackPtr + 1));
 
                 if ($next !== false) {
                     $end = $phpcsFile->findNext([T_SEMICOLON], ($stackPtr + 1));

--- a/src/InterNations/Sniffs/Whitespace/NamespaceWhitespaceSniff.php
+++ b/src/InterNations/Sniffs/Whitespace/NamespaceWhitespaceSniff.php
@@ -16,11 +16,7 @@ class NamespaceWhitespaceSniff implements CodeSnifferSniff
         $tokens = $file->getTokens();
 
         if ($tokens[$stackPtr - 1]['code'] === T_WHITESPACE) {
-            $file->addError(
-                'Invalid newline(s) before namespace declaration',
-                $stackPtr,
-                'WhitespaceBeforeNamespace'
-            );
+            $file->addError('Invalid newline(s) before namespace declaration', $stackPtr, 'WhitespaceBeforeNamespace');
         }
     }
 }

--- a/tests/InterNations/Tests/Sniffs/Formatting/ExpressionFormattingSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/ExpressionFormattingSniffTest.php
@@ -1,0 +1,225 @@
+<?php
+require_once __DIR__ . '/../AbstractTestCase.php';
+
+class InterNations_Tests_Sniffs_Formatting_ExpressionSniffTest extends InterNations_Tests_Sniffs_AbstractTestCase
+{
+    public function testSimpleInvocations()
+    {
+        $file = __DIR__ . '/Fixtures/SimpleInvocations.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(6, 0, $errors, $file);
+
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"call('argument');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall('argument');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall('argument', 'argument');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"StaticClass::methodCall('argument');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"return \$this->invoke('argument');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"invoke(123);\" should be in one line"
+        );
+    }
+
+    public function testMultiLineInvocations()
+    {
+        $file = __DIR__ . '/Fixtures/MultiLineInvocations.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(0, 0, $errors, $file);
+    }
+
+    public function testClosureInvocations()
+    {
+        $file = __DIR__ . '/Fixtures/ClosureInvocations.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(0, 0, $errors, $file);
+    }
+
+    public function testArrayInvocations()
+    {
+        $file = __DIR__ . '/Fixtures/ArrayInvocations.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(7, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall('argument', 'argument', [['foo', 'bar']]);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall('argument', 'argument', [array('foo', 'bar')]);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall(['argument']);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall('argument', 'argument', [['foo', 'bar' => 'test', \$key => 'value', 'key' => \$value, \$value]]);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$object->methodCall('argument', 'argument', [array('foo', 'bar')]);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"functionCall('argument', 'argument', [array('foo', 'bar', 'baz')]);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"functionCall(['foo' => true, 'bar' => false]);\" should be in one line"
+        );
+    }
+
+    public function testComplexInvocations()
+    {
+        $file = __DIR__ . '/Fixtures/ComplexInvocations.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(9, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"func(func(func(1, 2, ['required' => true])), 1.2, 'STRING');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"func(func(1, 2, ['required' => true])),\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$instance = new ClassName(['foo' => 'bar', 'member' => ClassName::class]);\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"functionCall('this', 'is', 'a', 'very', 'very', 'very', 'very', 'very', 'very', 'very', 'very', 'looong', 'invocation');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"parent::__construct('canBeOneLine');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"new self('canBeInOneLine');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"new static('canBeInOneLine');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"new Namespaced\\ClassName('canBeOneLine');\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"namespaced\\functionName('canBeOneLine');\" should be in one line"
+        );
+    }
+
+    public function testDeclarations()
+    {
+        $file = __DIR__ . '/Fixtures/Declarations.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(2, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"function test(\$argument1, \$argument2)\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"public function __construct(SomeClass \$foo)\" should be in one line"
+        );
+    }
+
+    public function testArrayAssignments()
+    {
+        $this->markTestSkipped('Skipped for now');
+        $file = __DIR__ . '/Fixtures/ArrayAssignments.php';
+        $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
+
+        $this->assertReportCount(3, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"\$array = ['canBeOneLine'];\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"'foo6' => ['can be one line']\" should be in one line"
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"return ['canTotallyBeOneLine'];\" should be in one line"
+        );
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ArrayAssignments.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ArrayAssignments.php
@@ -1,0 +1,21 @@
+<?php
+$array = [
+    'canBeOneLine'
+];
+
+
+$array = [
+    'foo0' => 'bar0',
+    'foo1' => 'bar1',
+    'foo2' => 'bar2',
+    'foo3' => 'bar3',
+    'foo4' => 'bar4',
+    'foo5' => 'bar5',
+    'foo6' => [
+        'can be one line'
+    ]
+];
+
+return [
+    'canTotallyBeOneLine'
+];

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ArrayInvocations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ArrayInvocations.php
@@ -1,0 +1,57 @@
+<?php
+functionCall(
+    [
+        'foo' => true,
+        'bar' => false
+    ]
+);
+
+$object->methodCall(
+    'argument',
+    'argument',
+    [
+        ['foo', 'bar']
+    ]
+);
+
+
+$object->methodCall(
+    'argument',
+    'argument',
+    [
+        ['foo', 'bar' => 'test', $key => 'value',
+                'key' => $value, $value]
+    ]
+);
+
+
+functionCall(
+    'argument',
+    'argument',
+    [
+        array(
+            'foo',
+            'bar',
+            'baz',
+        )
+    ]
+);
+
+$object->methodCall(
+    [
+        'argument',
+    ]
+);
+
+
+$object->methodCall(
+    ['argument']
+);
+
+$object->methodCall(
+    'argument',
+    'argument',
+    [
+        array('foo', 'bar')
+    ]
+);

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ClosureInvocations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ClosureInvocations.php
@@ -1,0 +1,14 @@
+<?php
+
+higherOrderFuncton(
+    static function (...$arguments) {
+        return $arguments;
+    }
+);
+
+
+$fn = function() {
+    $this->foo(function() {
+        return 1;
+    });
+};

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ComplexInvocations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/ComplexInvocations.php
@@ -1,0 +1,69 @@
+<?php
+func(
+    func(
+        func(1, 2, ['required' => true])
+    ),
+    1.2,
+
+
+    'STRING'
+);
+
+
+$instance = new ClassName(
+    ['foo'   => 'bar',
+    'member' => ClassName::class]
+);
+
+functionCall(
+    'this',
+    'is',
+    'a',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'loooong',
+    'invocation'
+);
+
+
+functionCall(
+    'this',
+    'is',
+    'a',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'very',
+    'looong',
+    'invocation'
+);
+
+
+new static(
+    'canBeInOneLine'
+);
+
+new self(
+    'canBeInOneLine'
+);
+
+parent::__construct(
+    'canBeOneLine'
+);
+new Namespaced\ClassName(
+    'canBeOneLine'
+);
+
+namespaced\functionName(
+    'canBeOneLine'
+);

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/Declarations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/Declarations.php
@@ -1,0 +1,18 @@
+<?php
+function test(
+    $argument1,
+    $argument2
+)
+{
+
+}
+
+class Test
+{
+    public function __construct(
+        SomeClass $foo
+    )
+    {
+
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/MultiLineInvocations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/MultiLineInvocations.php
@@ -1,0 +1,37 @@
+<?php
+$object->methodCall("
+foo
+bar");
+
+$object->methodCall('
+foo
+bar');
+
+StaticClass::methodCall(<<<EOS
+foo
+bar
+EOS
+);
+
+StaticClass::methodCall(<<<'EOS'
+foo
+bar
+EOS
+);
+
+functionCall(
+    'Comment' // With comment
+);
+
+
+functionCall(
+    'Comment' # With comment
+);
+
+functionCall(
+    'Comment' /* With comment */
+);
+
+functionCall(
+    'Comment' /** With comment */
+);

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/SimpleInvocations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/SimpleInvocations.php
@@ -1,0 +1,56 @@
+<?php
+call(
+    'argument'
+);
+
+call('argument');
+
+
+$object->methodCall(
+    'argument'
+);
+
+
+$object->methodCall(
+    'argument', 'argument'
+);
+
+
+higherOrderFuncton(
+    static function (...$arguments) {
+        return $arguments;
+    }
+);
+
+StaticClass::methodCall(
+    'argument'
+);
+
+
+function lalala() {
+
+}
+
+$fn = static function() {
+
+};
+
+namespace Lalala;
+class Foo
+{
+    use FooTrait;
+
+    public static function create()
+    {
+        return $this->invoke(
+            'argument'
+        );
+    }
+
+    public function method()
+    {
+        invoke(
+            123
+        );
+    }
+}


### PR DESCRIPTION
Enforces that:
- Declarations that fit a single line are in a single line
- Invocations that fit a a single line are in a single line (cleans up arrays accordingly)
