### PR TITLE
Check for empty line before control structure for better code readability

### DIFF
--- a/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
@@ -37,7 +37,7 @@ class EmptyLineBeforeControlStructureFormattingSniff implements CodeSnifferSniff
         ) {
             return;
         } elseif (count($prevLineTokens) > 0) {
-            $phpcsFile->addError('Missing blank line before '. $structureType . ' statement', $stackPtr);
+            $phpcsFile->addError('Missing blank line before ' . $structureType . ' statement', $stackPtr);
         }
     }
 }

--- a/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
@@ -1,0 +1,43 @@
+<?php
+namespace InterNations\Sniffs\Formatting;
+
+use PHP_CodeSniffer_File as CodeSnifferFile;
+use PHP_CodeSniffer_Sniff as CodeSnifferSniff;
+
+class EmptyLineBeforeControlStructureFormattingSniff implements CodeSnifferSniff
+{
+    public function register()
+    {
+        return [T_IF, T_SWITCH, T_FOR, T_FOREACH, T_WHILE, T_DO];
+    }
+
+    public function process(CodeSnifferFile $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $current = $stackPtr;
+
+        $structureType = $tokens[$current]['content'];
+
+        $previousLine = $tokens[$stackPtr]['line'] - 1;
+        $prevLineTokens = [];
+
+        while ($current >= 0 && $tokens[$current]['line'] >= $previousLine) {
+            if ($tokens[$current]['line'] === $previousLine
+                && $tokens[$current]['type'] !== 'T_WHITESPACE'
+                && $tokens[$current]['type'] !== 'T_COMMENT'
+            ) {
+                $prevLineTokens[] = $tokens[$current]['type'];
+            }
+            $current--;
+        }
+
+        if (isset($prevLineTokens[0])
+            && ($prevLineTokens[0] === 'T_OPEN_CURLY_BRACKET'
+                || $prevLineTokens[0] === 'T_COLON')
+        ) {
+            return;
+        } elseif (count($prevLineTokens) > 0) {
+            $phpcsFile->addError("Missing blank line before {$structureType} statement", $stackPtr);
+        }
+    }
+}

--- a/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
@@ -37,7 +37,7 @@ class EmptyLineBeforeControlStructureFormattingSniff implements CodeSnifferSniff
         ) {
             return;
         } elseif (count($prevLineTokens) > 0) {
-            $phpcsFile->addError("Missing blank line before {$structureType} statement", $stackPtr);
+            $phpcsFile->addError('Missing blank line before '. $structureType . ' statement', $stackPtr);
         }
     }
 }

--- a/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff.php
@@ -8,7 +8,7 @@ class EmptyLineBeforeControlStructureFormattingSniff implements CodeSnifferSniff
 {
     public function register()
     {
-        return [T_IF, T_SWITCH, T_FOR, T_FOREACH, T_WHILE, T_DO];
+        return [T_IF, T_SWITCH, T_FOR, T_FOREACH, T_WHILE, T_DO, T_RETURN];
     }
 
     public function process(CodeSnifferFile $phpcsFile, $stackPtr)

--- a/tests/InterNations/Tests/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniffTest.php
@@ -11,7 +11,7 @@ class InterNations_Tests_Sniffs_Formatting_EmptyLineBeforeControlStructureFormat
             [$file]
         );
 
-        $this->assertReportCount(6, 0, $errors, $file);
+        $this->assertReportCount(7, 0, $errors, $file);
 
         $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before if statement');
         $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before while statement');
@@ -19,6 +19,7 @@ class InterNations_Tests_Sniffs_Formatting_EmptyLineBeforeControlStructureFormat
         $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before switch statement');
         $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before for statement');
         $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before do statement');
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before return statement');
 
     }
 }

--- a/tests/InterNations/Tests/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniffTest.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../AbstractTestCase.php';
+
+class InterNations_Tests_Sniffs_Formatting_EmptyLineBeforeControlStructureFormattingSniffTest extends InterNations_Tests_Sniffs_AbstractTestCase
+{
+    public function testSimpleControlStructures()
+    {
+        $file = __DIR__ . '/Fixtures/SimpleControlStructures.php';
+        $errors = $this->analyze(
+            ['InterNations/Sniffs/Formatting/EmptyLineBeforeControlStructureFormattingSniff'],
+            [$file]
+        );
+
+        $this->assertReportCount(6, 0, $errors, $file);
+
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before if statement');
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before while statement');
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before foreach statement');
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before switch statement');
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before for statement');
+        $this->assertReportContains($errors, $file, 'errors', 'Missing blank line before do statement');
+
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/SimpleControlStructures.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/SimpleControlStructures.php
@@ -1,0 +1,39 @@
+<?php
+$b = true;
+if (true) {
+    $b = false;
+}
+
+$c = 1;
+while (false) {
+
+}
+// Shouldn't show error
+for ($i = 0; $i < 0; $i++) {
+
+}
+for ($i = 0; $i < 0; $i++) {
+
+}
+
+$c = 1;
+switch ($b) {
+    default:
+        break;
+}
+
+function test() {
+    if (true) {
+
+    }
+}
+
+$c = 1;
+foreach ([1] as $a) {
+
+}
+
+$c = 1;
+do {
+
+} while (false);

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/SimpleControlStructures.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/SimpleControlStructures.php
@@ -37,3 +37,12 @@ $c = 1;
 do {
 
 } while (false);
+
+function () {
+    return 0;
+}
+
+function () {
+    $c = 1;
+    return 0;
+}


### PR DESCRIPTION
To make code looks better I create this code sniff.
It control that we have a blank line before control structure (if, for, foreach, while, do, switch).