### PR TITLE
detect catching undefined exceptions

### DIFF
--- a/src/InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff.php
+++ b/src/InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff.php
@@ -1,0 +1,70 @@
+<?php
+namespace InterNations\Sniffs\ControlStructures;
+
+// @codingStandardsIgnoreFile
+require_once __DIR__ . '/../NamespaceSniffTrait.php';
+
+use InterNations\Sniffs\NamespaceSniffTrait;
+use PHP_CodeSniffer_File as CodeSnifferFile;
+use PHP_CodeSniffer_Sniff as CodeSnifferSniff;
+
+class CatchUndefinedExceptionSniff implements CodeSnifferSniff
+{
+    use NamespaceSniffTrait;
+
+    private static $aliases = [];
+
+    public function register()
+    {
+        return [T_USE, T_CATCH];
+    }
+
+    public function process(CodeSnifferFile $file, $stackPtr)
+    {
+        $tokens = $file->getTokens();
+        $fileName = $file->getFilename();
+
+        // Collect use statement aliases
+        if ($tokens[$stackPtr]['code'] === T_USE) {
+
+            /** function () use ($var) {} */
+            $previousPtr = $file->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
+            if ($tokens[$previousPtr]['code'] === T_CLOSE_PARENTHESIS) {
+                return;
+            }
+
+            /** use Trait; */
+            if ($file->findPrevious([T_CLASS, T_TRAIT], $stackPtr)) {
+                return;
+            }
+
+            list($stackPtr, $namespaceAlias, $fullyQualifiedNamespace) = $this->getNamespace($stackPtr + 1, $file);
+
+            if (!isset(static::$aliases[$fileName])) {
+                static::$aliases[$fileName] = [];
+            }
+
+            static::$aliases[$fileName][] = $namespaceAlias;
+
+            return;
+        }
+
+        // Check if aliased exist for caught exceptions
+        $catchPtr = $tokens[$stackPtr]['parenthesis_opener'] + 1;
+        $exceptionPtr = $file->findNext(
+            [T_CLASS, T_INTERFACE],
+            $catchPtr,
+            $tokens[$stackPtr]['parenthesis_closer'],
+            true
+        );
+
+        $exceptionName = $tokens[$exceptionPtr]['content'];
+
+        if (!in_array($exceptionName, static::$aliases[$fileName], false)) {
+            $file->addError(
+                sprintf('Trying to catch an undefined exception. Please add use-statement for "%s"', $exceptionName),
+                $exceptionPtr
+            );
+        }
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/ControlStructures/CatchUndefinedExceptionSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/ControlStructures/CatchUndefinedExceptionSniffTest.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../AbstractTestCase.php';
+
+class InterNations_Tests_Sniffs_ControlStructures_CatchUndefinedExceptionSniffTest
+    extends InterNations_Tests_Sniffs_AbstractTestCase
+{
+    public function testExistingExceptions()
+    {
+        $file = __DIR__ . '/Fixtures/ImportedExceptions.php';
+        $errors = $this->analyze(['InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff'], [$file]);
+
+        $this->assertReportCount(0, 0, $errors, $file);
+    }
+
+    public function testAliasedExceptions()
+    {
+        $file = __DIR__ . '/Fixtures/AliasedExceptions.php';
+        $errors = $this->analyze(['InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff'], [$file]);
+
+        $this->assertReportCount(0, 0, $errors, $file);
+    }
+
+    public function testUndefinedExceptions()
+    {
+        $file = __DIR__ . '/Fixtures/UndefinedExceptions.php';
+        $errors = $this->analyze(['InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff'], [$file]);
+
+        $this->assertReportCount(2, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Trying to catch an undefined exception. Please add use-statement for "UndefinedException"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Trying to catch an undefined exception. Please add use-statement for "UndefinedExceptionInterface"'
+        );
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/AliasedExceptions.php
+++ b/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/AliasedExceptions.php
@@ -1,0 +1,24 @@
+<?php
+namespace MyNamespace;
+
+use Exceptions\ExistingException as AliasException;
+use Exceptions\ExistingExceptionInterface as AliasExceptionInterface;
+
+class AliasedExceptions
+{
+    public function catchExistingException()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (AliasException $e) {
+        }
+    }
+
+    public function catchExistingExceptionInterface()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (AliasExceptionInterface $e) {
+        }
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/Exceptions/ExistingException.php
+++ b/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/Exceptions/ExistingException.php
@@ -1,0 +1,8 @@
+<?php
+namespace Exceptions;
+
+use Exception;
+
+class ExistingException extends Exception
+{
+}

--- a/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/Exceptions/ExistingExceptionInterface.php
+++ b/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/Exceptions/ExistingExceptionInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Exceptions;
+
+interface ExistingExceptionInterface
+{
+}

--- a/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/ImportedExceptions.php
+++ b/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/ImportedExceptions.php
@@ -1,0 +1,24 @@
+<?php
+namespace MyNamespace;
+
+use Exceptions\ExistingException;
+use Exceptions\ExistingExceptionInterface;
+
+class ImportedExceptions
+{
+    public function catchExistingException()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (ExistingException $e) {
+        }
+    }
+
+    public function catchExistingExceptionInterface()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (ExistingExceptionInterface $e) {
+        }
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/UndefinedExceptions.php
+++ b/tests/InterNations/Tests/Sniffs/ControlStructures/Fixtures/UndefinedExceptions.php
@@ -1,0 +1,40 @@
+<?php
+namespace MyNamespace;
+
+use Exceptions\ExistingException;
+use Exceptions\ExistingExceptionInterface;
+
+class UndefinedExceptions
+{
+    public function catchExistingException()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (ExistingException $e) {
+        }
+    }
+
+    public function catchExistingExceptionInterface()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (ExistingExceptionInterface $e) {
+        }
+    }
+
+    public function catchUndefinedException()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (UndefinedException $e) {
+        }
+    }
+
+    public function catchUndefinedExceptionInterface()
+    {
+        try {
+            ; // Something might throw an exception
+        } catch (UndefinedExceptionInterface $e) {
+        }
+    }
+}


### PR DESCRIPTION
This sniff is meant to find cases when you are trying to catch an exception but forgot to "use" it properly, so it would only match when the exception is defined in the same namespace as the current class, which is almost never the case.