### PR TITLE
Implement a sniff for common dependencies

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -218,6 +218,9 @@
     <rule ref="Squiz.Classes.ValidClassName"/>
     <!-- Bugfix sniff -->
     <rule ref="./src/InterNations/Sniffs/ControlStructures/SwitchDeclarationSniff.php"/>
+	<rule ref="./src/InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff.php"/>
+    <rule ref="./src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php"/>
+    <rule ref="./src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php"/>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -218,7 +218,7 @@
     <rule ref="Squiz.Classes.ValidClassName"/>
     <!-- Bugfix sniff -->
     <rule ref="./src/InterNations/Sniffs/ControlStructures/SwitchDeclarationSniff.php"/>
-	<rule ref="./src/InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff.php"/>
+    <rule ref="./src/InterNations/Sniffs/ControlStructures/CatchUndefinedExceptionSniff.php"/>
     <rule ref="./src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php"/>
     <rule ref="./src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php"/>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>

--- a/src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php
+++ b/src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php
@@ -1,0 +1,139 @@
+<?php
+namespace InterNations\Sniffs\BestPractice;
+
+use PHP_CodeSniffer_File as CodeSnifferFile;
+use PHP_CodeSniffer_Sniff as CodeSnifferSniff;
+
+class CommonDependenciesSniff implements CodeSnifferSniff
+{
+    private static $commonSymbolNames = [
+        'EntityManager' => 'em',
+        'EntityManagerInterface' => 'em',
+        'ObjectManager' => 'om',
+        'EngineInterface' => 'templating',
+    ];
+
+    public function register()
+    {
+        return [T_FUNCTION];
+    }
+
+    public function process(CodeSnifferFile $file, $stackPtr)
+    {
+        $methodName = $file->getDeclarationName($stackPtr);
+
+        if ($methodName !== '__construct' && strpos($methodName, 'set') !== 0) {
+            return;
+        }
+
+
+        $methodParameters = $file->getMethodParameters($stackPtr);
+
+        foreach ($methodParameters as $methodParameter) {
+            $this->verifyParameterName($file, $stackPtr, $methodName, $methodParameter);
+        }
+
+
+        $propertyAssignments = $this->getPropertyAssignments($file, $stackPtr);
+
+        foreach ($methodParameters as $methodParameter) {
+            $this->verifyPropertyName($file, $stackPtr, $methodName, $methodParameter, $propertyAssignments);
+        }
+    }
+
+    private function verifyParameterName(CodeSnifferFile $file, $stackPtr, $methodName, array $methodParameter)
+    {
+        $name = ltrim($methodParameter['name'], '$');
+        $typeHint = $methodParameter['type_hint'];
+
+        if (!isset(self::$commonSymbolNames[$typeHint]) || self::$commonSymbolNames[$typeHint] === $name) {
+            return;
+        }
+
+        $file->addError(
+            'Parameter "$%s" ("%s") of method "%s" must be called "$%s"',
+            $stackPtr,
+            'ParameterName',
+            [$name, $typeHint, $methodName, self::$commonSymbolNames[$typeHint]]
+        );
+    }
+
+    private function verifyPropertyName(
+        CodeSnifferFile $file,
+        $stackPtr,
+        $methodName,
+        array $methodParameter,
+        array $assignments
+    )
+    {
+        $parameterName = ltrim($methodParameter['name'], '$');
+        $typeHint = $methodParameter['type_hint'];
+
+        if (!isset(self::$commonSymbolNames[$typeHint], $assignments[$methodParameter['name']])) {
+            return;
+        }
+
+
+        $propertyName = $assignments[$methodParameter['name']];
+
+        if (self::$commonSymbolNames[$typeHint] === $propertyName) {
+            return;
+        }
+
+
+        $file->addError(
+            'Property "$%s" assigned from parameter "$%s" ("%s") of method "%s" must be called "$%s"',
+            $stackPtr,
+            'PropertyName',
+            [$propertyName, $parameterName, $typeHint, $methodName, self::$commonSymbolNames[$typeHint]]
+        );
+    }
+
+    private function getPropertyAssignments(CodeSnifferFile $file, $stackPtr)
+    {
+        $tokens = $file->getTokens();
+        $currentToken = $tokens[$stackPtr];
+
+        if (!isset($currentToken['scope_opener'])) {
+            return [];
+        }
+
+        $ptr = $currentToken['scope_opener'];
+        $endOfMethodPtr = $currentToken['scope_closer'];
+
+
+        $assignments = [];
+
+        while ($ptr && $ptr < $endOfMethodPtr) {
+
+            $thisPtr = $file->findNext([T_SELF, T_STATIC, T_VARIABLE], $ptr, $endOfMethodPtr, false, null, true);
+            $ptr = $file->findNext([], $ptr + 1, $endOfMethodPtr, true, null, true);
+
+            if (!$thisPtr
+                || !in_array($tokens[$thisPtr]['content'], ['$this', 'static', 'self'], true)
+                || !in_array($tokens[$thisPtr + 1]['code'], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)
+                || !in_array($tokens[$thisPtr + 2]['code'], [T_STRING, T_VARIABLE], true)
+            ) {
+                continue;
+            }
+
+
+            $equalPtr = $file->findNext(T_WHITESPACE, $thisPtr + 3, $endOfMethodPtr, true, null, true);
+
+            if (!$equalPtr || $tokens[$equalPtr]['code'] !== T_EQUAL) {
+                continue;
+            }
+
+
+            $variablePtr = $file->findNext(T_WHITESPACE, $equalPtr + 1, $endOfMethodPtr, true, null, true);
+
+            if (!$variablePtr || $tokens[$variablePtr]['code'] !== T_VARIABLE) {
+                continue;
+            }
+
+            $assignments[$tokens[$variablePtr]['content']] = ltrim($tokens[$thisPtr + 2]['content'], '$');
+        }
+
+        return $assignments;
+    }
+}

--- a/src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php
+++ b/src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php
@@ -14,6 +14,7 @@ class CommonDependenciesSniff implements CodeSnifferSniff
         'Symfony\Bundle\FrameworkBundle\Templating\EngineInterface' => 'templating',
         'Symfony\Component\EventDispatcher\EventDispatcherInterface' => 'dispatcher',
         'Symfony\Component\EventDispatcher\EventDispatcher' => 'dispatcher',
+        'Psr\Log\LoggerInterface' => 'logger',
     ];
 
     public function register()

--- a/src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php
+++ b/src/InterNations/Sniffs/BestPractice/CommonDependenciesSniff.php
@@ -12,6 +12,8 @@ class CommonDependenciesSniff implements CodeSnifferSniff
         'Doctrine\Common\Persistence\ObjectManager' => 'om',
         'Symfony\Component\Templating\EngineInterface' => 'templating',
         'Symfony\Bundle\FrameworkBundle\Templating\EngineInterface' => 'templating',
+        'Symfony\Component\EventDispatcher\EventDispatcherInterface' => 'dispatcher',
+        'Symfony\Component\EventDispatcher\EventDispatcher' => 'dispatcher',
     ];
 
     public function register()

--- a/tests/InterNations/Tests/Sniffs/BestPractice/CommonDependenciesSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/BestPractice/CommonDependenciesSniffTest.php
@@ -101,7 +101,7 @@ class InterNations_Tests_Sniffs_BestPractice_CommonDependenciesSniffTest
             $file,
             'errors',
             'Property "$entityManager" assigned from parameter "$entityManager" ("EntityManager") of method '
-                . '"setEntityManager" must be called "$em"'
+            . '"setEntityManager" must be called "$em"'
         );
         $this->assertReportContains(
             $errors,
@@ -114,7 +114,41 @@ class InterNations_Tests_Sniffs_BestPractice_CommonDependenciesSniffTest
             $file,
             'errors',
             'Property "$entityManager" assigned from parameter "$entityManager" ("EntityManager") of method '
-                . '"setAnotherEntityManager" must be called "$em"'
+            . '"setAnotherEntityManager" must be called "$em"'
+        );
+    }
+
+    public function testSymfonyVariableNamesAreEnforced()
+    {
+        $file = __DIR__ . '/Fixtures/CommonDependencies/Symfony.php';
+        $errors = $this->analyze(['InterNations/Sniffs/BestPractice/CommonDependenciesSniff'], [$file]);
+
+        $this->assertReportCount(4, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$eventDispatcher" ("EventDispatcherInterface") of method "__construct" must '
+            . 'be called "$dispatcher"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$engine" ("EngineInterface") of method "__construct" must be called "$templating"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$ed" ("EventDispatcher") of method "__construct" must be called "$dispatcher"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$eventDispatcherProperty" assigned from parameter "$eventDispatcher" '
+            . '("EventDispatcherInterface") of method "__construct" must be called "$dispatcher"'
         );
     }
 }

--- a/tests/InterNations/Tests/Sniffs/BestPractice/CommonDependenciesSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/BestPractice/CommonDependenciesSniffTest.php
@@ -1,0 +1,120 @@
+<?php
+require_once __DIR__ . '/../AbstractTestCase.php';
+
+class InterNations_Tests_Sniffs_BestPractice_CommonDependenciesSniffTest
+    extends InterNations_Tests_Sniffs_AbstractTestCase
+{
+    public function testDoctrineCommonVariableNamesAreEnforced()
+    {
+        $file = __DIR__ . '/Fixtures/CommonDependencies/Doctrine.php';
+        $errors = $this->analyze(['InterNations/Sniffs/BestPractice/CommonDependenciesSniff'], [$file]);
+
+        $this->assertReportCount(10, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$entityManager" ("EntityManager") of method "__construct" must be called "$em"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$objectManager" ("ObjectManager") of method "__construct" must be called "$om"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$objectManagerProperty" assigned from parameter "$objectManager" ("ObjectManager") of method '
+            . '"__construct" must be called "$om"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$entityManagerProperty" assigned from parameter "$entityManager" ("EntityManager") of method '
+            . '"__construct" must be called "$em"'
+        );
+
+
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$entityManager" ("EntityManager") of method "setEntityManagerProperty" must be called "$em"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$entityManagerProperty" assigned from parameter "$entityManager" ("EntityManager") of method '
+                . '"setEntityManagerProperty" must be called "$em"'
+        );
+
+
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$objectManager" ("ObjectManager") of method "setObjectManagerProperty" must be called "$om"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$objectManagerProperty" assigned from parameter "$objectManager" ("ObjectManager") of method '
+                . '"setObjectManagerProperty" must be called "$om"'
+        );
+
+
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$entityManager" ("EntityManagerInterface") of method "setAnotherEntityManager" must '
+                . 'be called "$em"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$entityManagerProperty" assigned from parameter "$entityManager" ("EntityManagerInterface") '
+                . 'of method "setAnotherEntityManager" must be called "$em"'
+        );
+    }
+
+    public function testStaticVariableNamesAreEnforced()
+    {
+        $file = __DIR__ . '/Fixtures/CommonDependencies/StaticVariants.php';
+        $errors = $this->analyze(['InterNations/Sniffs/BestPractice/CommonDependenciesSniff'], [$file]);
+
+        $this->assertReportCount(4, 0, $errors, $file);
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$entityManager" ("EntityManager") of method "setEntityManager" must be called "$em"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$entityManager" assigned from parameter "$entityManager" ("EntityManager") of method '
+                . '"setEntityManager" must be called "$em"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Parameter "$entityManager" ("EntityManager") of method "setAnotherEntityManager" must be called "$em"'
+        );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            'Property "$entityManager" assigned from parameter "$entityManager" ("EntityManager") of method '
+                . '"setAnotherEntityManager" must be called "$em"'
+        );
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/Doctrine.php
+++ b/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/Doctrine.php
@@ -1,0 +1,36 @@
+<?php
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class Klass
+{
+    private $entityManagerProperty;
+
+    private $objectManagerProperty;
+
+    public function __construct(EntityManager $entityManager, ObjectManager $objectManager, Something $something)
+    {
+        $this->entityManagerProperty = $entityManager;
+        $this->objectManagerProperty = $objectManager;
+    }
+
+    public function setEntityManagerProperty(EntityManager $entityManager)
+    {
+        $this->entityManagerProperty = $entityManager;
+    }
+
+    public function setObjectManagerProperty(ObjectManager $objectManager)
+    {
+        $this->objectManagerProperty = $objectManager;
+    }
+
+    public function setAnotherEntityManager(EntityManagerInterface $entityManager)
+    {
+        $this->entityManagerProperty = $entityManager;
+    }
+
+    public function getSomething()
+    {
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/Doctrine.php
+++ b/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/Doctrine.php
@@ -1,4 +1,5 @@
 <?php
+use Doctrine\ORM\EntityManager as Foo;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Common\Persistence\ObjectManager;

--- a/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/StaticVariants.php
+++ b/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/StaticVariants.php
@@ -1,0 +1,19 @@
+<?php
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class Klass
+{
+    private static $entityManager;
+
+    public static function setEntityManager(EntityManager $entityManager)
+    {
+        static::$entityManager = $entityManager;
+    }
+
+    public static function setAnotherEntityManager(EntityManager $entityManager)
+    {
+        self::$entityManager = $entityManager;
+    }
+}

--- a/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/Symfony.php
+++ b/tests/InterNations/Tests/Sniffs/BestPractice/Fixtures/CommonDependencies/Symfony.php
@@ -1,0 +1,14 @@
+<?php
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+
+class Klass
+{
+    private $eventDispatcherProperty;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, EventDispatcher $ed, EngineInterface $engine)
+    {
+        $this->eventDispatcherProperty = $eventDispatcher;
+    }
+}


### PR DESCRIPTION
Ensures that common dependencies have the same naming scheme for properties and parameters. So far:

 - EngineInterface -> templating
 - EntityManagerInterface -> em
 - EntityManager -> em
 - ObjectManager -> om

Other ideas: 
 - Doctrine\DBAL\Connection -> database or connection
 - UrlGeneratorInterface -> urlGenerator