### PR TITLE
Consider return type as part of an expression for function declarations

### DIFF
--- a/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
@@ -50,6 +50,7 @@ class ExpressionFormattingSniff implements CodeSnifferSniff
             $closingPtr = $openingToken['parenthesis_closer'];
 
             $nextNonWhitespacePos = $file->findNext(T_WHITESPACE, $closingPtr + 1, null, true);
+
             if ($tokens[$nextNonWhitespacePos]['code'] === T_COLON) {
                 $closingPtr = $file->findNext(T_RETURN_TYPE, $nextNonWhitespacePos + 1);
             }
@@ -138,22 +139,24 @@ class ExpressionFormattingSniff implements CodeSnifferSniff
 
         } while ($tokens[$stackPtr]['line'] === $tokens[$startPtr]['line']);
 
-        $endPtr = $expressionPtr;
+        $endPtr = $expressionPtr + 1;
 
-        do {
+        while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']) {
             ++$endPtr;
-        } while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']);
+        }
 
         $nextPtr = $endPtr;
+
         while ($tokens[$nextPtr]['code'] === T_WHITESPACE) {
             ++$nextPtr;
         }
 
         if ($tokens[$nextPtr]['code'] === T_COLON) {
             $endPtr = $nextPtr;
-            do {
+
+            while ($tokens[$endPtr]['code'] !== T_RETURN_TYPE) {
                 ++$endPtr;
-            } while ($tokens[$endPtr]['code'] !== T_RETURN_TYPE);
+            }
         }
 
         $before = static::composeExpression($tokens, $startPtr + 1, $stackPtr + 1);

--- a/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
@@ -140,11 +140,11 @@ class ExpressionFormattingSniff implements CodeSnifferSniff
 
         $endPtr = $expressionPtr;
 
-        while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']) {
+        do {
             ++$endPtr;
-        }
+        } while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']);
 
-        $nextPtr = $endPtr + 1;
+        $nextPtr = $endPtr;
         while ($tokens[$nextPtr]['code'] === T_WHITESPACE) {
             ++$nextPtr;
         }

--- a/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
+++ b/src/InterNations/Sniffs/Formatting/ExpressionFormattingSniff.php
@@ -140,10 +140,21 @@ class ExpressionFormattingSniff implements CodeSnifferSniff
 
         $endPtr = $expressionPtr;
 
-        do {
+        while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']) {
             ++$endPtr;
+        }
 
-        } while ($tokens[$stackPtr]['line'] === $tokens[$endPtr]['line']);
+        $nextPtr = $endPtr + 1;
+        while ($tokens[$nextPtr]['code'] === T_WHITESPACE) {
+            ++$nextPtr;
+        }
+
+        if ($tokens[$nextPtr]['code'] === T_COLON) {
+            $endPtr = $nextPtr;
+            do {
+                ++$endPtr;
+            } while ($tokens[$endPtr]['code'] !== T_RETURN_TYPE);
+        }
 
         $before = static::composeExpression($tokens, $startPtr + 1, $stackPtr + 1);
         $after = static::composeExpression($tokens, $expressionPtr, $endPtr);

--- a/tests/InterNations/Tests/Sniffs/Formatting/ExpressionFormattingSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/ExpressionFormattingSniffTest.php
@@ -196,7 +196,7 @@ class InterNations_Tests_Sniffs_Formatting_ExpressionSniffTest extends InterNati
         $file = __DIR__ . '/Fixtures/Declarations.php';
         $errors = $this->analyze(['InterNations/Sniffs/Formatting/ExpressionFormattingSniff'], [$file]);
 
-        $this->assertReportCount(2, 0, $errors, $file);
+        $this->assertReportCount(3, 0, $errors, $file);
         $this->assertReportContains(
             $errors,
             $file,
@@ -209,6 +209,14 @@ class InterNations_Tests_Sniffs_Formatting_ExpressionSniffTest extends InterNati
             'errors',
             "Expression \"public function __construct(SomeClass \$foo)\" should be in one line"
         );
+        $this->assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            "Expression \"public function createTest(array \$fakeVariable, int \$secondFakeArgument, " .
+            "string \$thirdFakeArgument): Test\" should be in one line"
+        );
+
     }
 
     public function testArrayAssignments()

--- a/tests/InterNations/Tests/Sniffs/Formatting/ExpressionFormattingSniffTest.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/ExpressionFormattingSniffTest.php
@@ -214,7 +214,7 @@ class InterNations_Tests_Sniffs_Formatting_ExpressionSniffTest extends InterNati
             $file,
             'errors',
             "Expression \"public function createTest(array \$fakeVariable, int \$secondFakeArgument, " .
-            "string \$thirdFakeArgument): Test\" should be in one line"
+            "string \$thirdFakeArgument):Test\" should be in one line"
         );
 
     }

--- a/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/Declarations.php
+++ b/tests/InterNations/Tests/Sniffs/Formatting/Fixtures/Declarations.php
@@ -16,3 +16,28 @@ class Test
 
     }
 }
+
+class TestTwo
+{
+    public function createTest(
+        array $fakeVariable,
+        int $secondFakeArgument,
+        string $thirdFakeArgument,
+        bool $false
+    ): Test
+    {
+        return new Test();
+    }
+}
+
+class TestThree
+{
+    public function createTest(
+        array $fakeVariable,
+        int $secondFakeArgument,
+        string $thirdFakeArgument
+    ): Test
+    {
+        return new Test();
+    }
+}


### PR DESCRIPTION
Return type was not considered to be a part of an expression when
validating multi-line expression elngth