### PR TITLE
Allow use head as action name in web and api controllers

### DIFF
--- a/src/InterNations/Sniffs/Architecture/ControllerMethodsConventionSniff.php
+++ b/src/InterNations/Sniffs/Architecture/ControllerMethodsConventionSniff.php
@@ -13,7 +13,7 @@ class ControllerMethodsConventionSniff implements Sniff
         'set*'
     ];
 
-    private static $apiVerbs = ['index', 'get', 'post', 'put', 'patch', 'delete'];
+    private static $apiVerbs = ['index', 'get', 'post', 'put', 'patch', 'delete', 'head'];
 
     private static $webVerbs = ['new', 'edit'];
 

--- a/src/InterNations/Tests/Sniffs/Architecture/ControllerMethodsConventionSniffTest.php
+++ b/src/InterNations/Tests/Sniffs/Architecture/ControllerMethodsConventionSniffTest.php
@@ -15,7 +15,7 @@ class ControllerMethodsConventionSniffTest extends AbstractTestCase
             $errors,
             $file,
             'errors',
-            'Public methods in web controllers are limited to "deleteAction()", "editAction()", "getAction()", "indexAction()", "newAction()", "patchAction()", "postAction()", "putAction()" but "invalidAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
+            'Public methods in web controllers are limited to "deleteAction()", "editAction()", "getAction()", "headAction()", "indexAction()", "newAction()", "patchAction()", "postAction()", "putAction()" but "invalidAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
         );
     }
 
@@ -37,19 +37,19 @@ class ControllerMethodsConventionSniffTest extends AbstractTestCase
             $errors,
             $file,
             'errors',
-            'Public methods in API controllers are limited to "deleteAction()", "getAction()", "indexAction()", "patchAction()", "postAction()", "putAction()" but "newAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
+            'Public methods in API controllers are limited to "deleteAction()", "getAction()", "headAction()", "indexAction()", "patchAction()", "postAction()", "putAction()" but "newAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
         );
         static::assertReportContains(
             $errors,
             $file,
             'errors',
-            'Public methods in API controllers are limited to "deleteAction()", "getAction()", "indexAction()", "patchAction()", "postAction()", "putAction()" but "editAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
+            'Public methods in API controllers are limited to "deleteAction()", "getAction()", "headAction()", "indexAction()", "patchAction()", "postAction()", "putAction()" but "editAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
         );
         static::assertReportContains(
             $errors,
             $file,
             'errors',
-            'Public methods in API controllers are limited to "deleteAction()", "getAction()", "indexAction()", "patchAction()", "postAction()", "putAction()" but "invalidAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
+            'Public methods in API controllers are limited to "deleteAction()", "getAction()", "headAction()", "indexAction()", "patchAction()", "postAction()", "putAction()" but "invalidAction()" found. This is often a hint that you are dealing with a sub resource of the current resource that justifies its own controller and should be extracted into its own controller.'
         );
     }
 }

--- a/src/InterNations/Tests/Sniffs/Architecture/Fixtures/InterNations/Bundle/SomethingBundle/Controller/Api/TestController.php
+++ b/src/InterNations/Tests/Sniffs/Architecture/Fixtures/InterNations/Bundle/SomethingBundle/Controller/Api/TestController.php
@@ -25,6 +25,8 @@ class TestController
 
     public function indexAction() { }
 
+    public function headAction() { }
+
     public function invalidAction() { }
 
     protected function whateverProtected() { }


### PR DESCRIPTION
When we are using REST API, it's possible to create HEAD api request. 
This pull request extend list of whitelisted methods name to allow use also 'headAction'

Example code :

```php
    /**
     * @ApiDoc(description="Ping", section="Ping")
     * @Rest\Head(path="/api/logs", name="api_ping_head")
     *
     * @Rest\View(statusCode=204)
     */
    public function headAction(): View
```