### PR TITLE
Improvements for testing classes

### DIFF
--- a/tests/InterNations/Formatting/ExpressionFormattingSniffTest.php
+++ b/tests/InterNations/Formatting/ExpressionFormattingSniffTest.php
@@ -3,7 +3,7 @@ namespace InterNations\Sniffs\Tests\Formatting;
 
 use InterNations\Sniffs\Tests\AbstractTestCase;
 
-class ExpressionSniffTest extends AbstractTestCase
+class ExpressionFormattingSniffTest extends AbstractTestCase
 {
     public function testSimpleInvocations(): void
     {

--- a/tests/InterNations/Syntax/BracesSniffTest.php
+++ b/tests/InterNations/Syntax/BracesSniffTest.php
@@ -3,7 +3,7 @@ namespace InterNations\Sniffs\Tests\Syntax;
 
 use InterNations\Sniffs\Tests\AbstractTestCase;
 
-class BracesTest extends AbstractTestCase
+class BracesSniffTest extends AbstractTestCase
 {
     public function testInvalidDocBlocks(): void
     {

--- a/tests/InterNations/Syntax/ShortArraySyntaxSniffTest.php
+++ b/tests/InterNations/Syntax/ShortArraySyntaxSniffTest.php
@@ -3,7 +3,7 @@ namespace InterNations\Sniffs\Tests\Syntax;
 
 use InterNations\Sniffs\Tests\AbstractTestCase;
 
-class ShortArraySniffTest extends AbstractTestCase
+class ShortArraySyntaxSniffTest extends AbstractTestCase
 {
     public function testOneLineOk(): void
     {

--- a/tests/InterNations/Syntax/ShortListSyntaxSniffTest.php
+++ b/tests/InterNations/Syntax/ShortListSyntaxSniffTest.php
@@ -3,7 +3,7 @@ namespace InterNations\Sniffs\Tests\Syntax;
 
 use InterNations\Sniffs\Tests\AbstractTestCase;
 
-class ShortListSniffTest extends AbstractTestCase
+class ShortListSyntaxSniffTest extends AbstractTestCase
 {
     public function testShortListSyntax(): void
     {


### PR DESCRIPTION
# Changed log

- Letting the testing class name should be same as PHP file name.