### PR TITLE
Discouraged DBAL Constant rule

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     name: PHP ${{ matrix.php-version }}
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/src/InterNations/Sniffs/BestPractice/DiscouragedConstantSniff.php
+++ b/src/InterNations/Sniffs/BestPractice/DiscouragedConstantSniff.php
@@ -1,0 +1,37 @@
+<?php
+namespace InterNations\Sniffs\BestPractice;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class DiscouragedConstantSniff implements Sniff
+{
+    public function register(): array
+    {
+        return [T_STRING, T_DOUBLE_COLON];
+    }
+
+    public function process(File $file, $stackPtr): void
+    {
+        $tokens = $file->getTokens();
+
+        $constantName = $tokens[$stackPtr - 1]['content']
+            . $tokens[$stackPtr]['content']
+            . $tokens[$stackPtr + 1]['content'];
+
+        if ($constantName === 'Types::SIMPLE_ARRAY') {
+            $params = [
+                $constantName,
+                '\Doctrine\DBAL\Connection::PARAM_STR_ARRAY',
+                '\Doctrine\DBAL\Connection::PARAM_INT_ARRAY',
+            ];
+            $file->addError(
+                'Usage of %s is discouraged. '
+                . 'It`s more likely that you want %s or %s instead to escape SQL IN() statements.',
+                $stackPtr,
+                'DiscouragedConstantFound',
+                $params
+            );
+        }
+    }
+}

--- a/src/InterNations/Sniffs/BestPractice/DiscouragedConstantSniff.php
+++ b/src/InterNations/Sniffs/BestPractice/DiscouragedConstantSniff.php
@@ -19,7 +19,7 @@ class DiscouragedConstantSniff implements Sniff
             . $tokens[$stackPtr]['content']
             . $tokens[$stackPtr + 1]['content'];
 
-        if ($constantName === 'Types::SIMPLE_ARRAY') {
+        if ($constantName === 'Types::SIMPLE_ARRAY' || $constantName === 'Type::SIMPLE_ARRAY') {
             $params = [
                 $constantName,
                 '\Doctrine\DBAL\Connection::PARAM_STR_ARRAY',

--- a/tests/InterNations/BestPractice/DiscouragedConstantSniffTest.php
+++ b/tests/InterNations/BestPractice/DiscouragedConstantSniffTest.php
@@ -10,7 +10,7 @@ class DiscouragedConstantSniffTest extends AbstractTestCase
         $file = __DIR__ . '/Fixtures/DiscouragedConstant/SomeRepository.php';
         $errors = self::analyze(['InterNations/Sniffs/BestPractice/DiscouragedConstantSniff'], [$file]);
 
-        self::assertReportCount(1, 0, $errors, $file);
+        self::assertReportCount(2, 0, $errors, $file);
         self::assertReportContains(
             $errors,
             $file,
@@ -19,6 +19,18 @@ class DiscouragedConstantSniffTest extends AbstractTestCase
                 'Usage of %s is discouraged. '
                 . 'It`s more likely that you want %s or %s instead to escape SQL IN() statements.',
                 'Types::SIMPLE_ARRAY',
+                '\Doctrine\DBAL\Connection::PARAM_STR_ARRAY',
+                '\Doctrine\DBAL\Connection::PARAM_INT_ARRAY',
+            )
+        );
+        self::assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            sprintf(
+                'Usage of %s is discouraged. '
+                . 'It`s more likely that you want %s or %s instead to escape SQL IN() statements.',
+                'Type::SIMPLE_ARRAY',
                 '\Doctrine\DBAL\Connection::PARAM_STR_ARRAY',
                 '\Doctrine\DBAL\Connection::PARAM_INT_ARRAY',
             )

--- a/tests/InterNations/BestPractice/DiscouragedConstantSniffTest.php
+++ b/tests/InterNations/BestPractice/DiscouragedConstantSniffTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace InterNations\Sniffs\Tests\BestPractice;
+
+use InterNations\Sniffs\Tests\AbstractTestCase;
+
+class DiscouragedConstantSniffTest extends AbstractTestCase
+{
+    public function testDoctrineTypesSimpleArrayIsNotEncouraged(): void
+    {
+        $file = __DIR__ . '/Fixtures/DiscouragedConstant/SomeRepository.php';
+        $errors = self::analyze(['InterNations/Sniffs/BestPractice/DiscouragedConstantSniff'], [$file]);
+
+        self::assertReportCount(1, 0, $errors, $file);
+        self::assertReportContains(
+            $errors,
+            $file,
+            'errors',
+            sprintf(
+                'Usage of %s is discouraged. '
+                . 'It`s more likely that you want %s or %s instead to escape SQL IN() statements.',
+                'Types::SIMPLE_ARRAY',
+                '\Doctrine\DBAL\Connection::PARAM_STR_ARRAY',
+                '\Doctrine\DBAL\Connection::PARAM_INT_ARRAY',
+            )
+        );
+    }
+}

--- a/tests/InterNations/BestPractice/Fixtures/DiscouragedConstant/SomeRepository.php
+++ b/tests/InterNations/BestPractice/Fixtures/DiscouragedConstant/SomeRepository.php
@@ -1,0 +1,24 @@
+<?php
+namespace InterNations\BestPractice\Fixtures\DiscouragedConstant;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Types\Types;
+class SomeRepository
+{
+    private EntityManagerInterface $em;
+    public function tryFind(): int
+    {
+        $sql = 'SELECT 1 FROM foo WHERE bar IN(:inputs)';
+
+        $params = [
+            'inputs' => [1,2,3],
+        ];
+
+        $types = [
+            'inputs' => Types::SIMPLE_ARRAY,
+        ];
+
+        return (int) $this->em->getConnection()
+            ->executeStatement($sql, $params, $types);
+    }
+}

--- a/tests/InterNations/BestPractice/Fixtures/DiscouragedConstant/SomeRepository.php
+++ b/tests/InterNations/BestPractice/Fixtures/DiscouragedConstant/SomeRepository.php
@@ -3,19 +3,22 @@ namespace InterNations\BestPractice\Fixtures\DiscouragedConstant;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\Types\Type;
 class SomeRepository
 {
     private EntityManagerInterface $em;
     public function tryFind(): int
     {
-        $sql = 'SELECT 1 FROM foo WHERE bar IN(:inputs)';
+        $sql = 'SELECT 1 FROM foo WHERE bar IN(:inputs) OR foobar NOT IN (:exclude)';
 
         $params = [
             'inputs' => [1,2,3],
+            'exclude' => ['a', 'b']
         ];
 
         $types = [
             'inputs' => Types::SIMPLE_ARRAY,
+            'exclude' => Type::SIMPLE_ARRAY,
         ];
 
         return (int) $this->em->getConnection()


### PR DESCRIPTION
Discourage usage of Types::SIMPLE_ARRAY it does not escape values properly and only implodes values and passes them into the statement as a single string

`['a','b']` becomes `WHERE foo IN ('a,b')`

What we want instead most of the time is `\Doctrine\DBAL\Connection::PARAM_STR_ARRAY` or `\Doctrine\DBAL\Connection::PARAM_INT_ARRAY`